### PR TITLE
Add filter for Windowe

### DIFF
--- a/src/parse-cmd.js
+++ b/src/parse-cmd.js
@@ -25,6 +25,13 @@ const parseCmd = (params = []) => {
     params.shift();
   }
 
+  // remove for Windows
+  if (params.length > 1 && process.platform === "win32") {
+    const regex = new RegExp('[a-zA-Z]:\\.*');
+    const result = params.filter(param => !regex.test(param));
+    params = result;
+  }
+  
   let [scriptName, ...options] = params;
 
   const optionsSeparator = "--";


### PR DESCRIPTION
when we run nprr or nprr Something, we get the error: "Error: No scripts available"
this is caused by the "parse-cmd.js" script which in the "params" variable contains in my case 2 system links:
C:\\Program Files\\nodejs\\node.exe
C:\\Users\\USERNAME\\AppData\\Roaming\\npm\\node_modules\\nprr\\src\\bin.js

when the script looks in the script names of the pakage.json it looks for the first element here C:\\Program Files\\nodejs\\node.exe which results in the error.

So I added a filter that checks if the elements of "params" start with "[a-zA-Z]:\", to remove them.

the modification has no impact on other OS than Windwos, I test if it is Windows if not it is to be ignored